### PR TITLE
[WIP] Initial testing of Browser Update

### DIFF
--- a/edx-platform/israelxedu.gov.il/lms/templates/header.html
+++ b/edx-platform/israelxedu.gov.il/lms/templates/header.html
@@ -6,7 +6,25 @@ from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
+
+% if configuration_helpers.get_value('ENABLE_UNSUPPORTED_BROWSER_ALERT', settings.FEATURES.get('ENABLE_UNSUPPORTED_BROWSER_ALERT', True)):
+  <script>
+  var $buoop = {notify:${configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS', "{i:-3,f:-3,o:-3,s:-3,c:-3}"))|h},
+    insecure:true,
+    api:5,
+    l:"${LANGUAGE_CODE}",
+    reminder:0};
+  function $buo_f(){
+   var e = document.createElement("script");
+   e.src = "//browser-update.org/update.min.js";
+   document.body.appendChild(e);
+  };
+  try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
+  catch(e){window.attachEvent("onload", $buo_f)}
+  </script>
+% endif
 
 
 <header id="global-navigation" class="header-main" >


### PR DESCRIPTION
## CAM-51

### Description

This PR adds the Browser-Update script to notify the user when their browsers are out of date.

According to the screenshot of the conversation in Jira, the script it's configured to 3 versions backward of IE/Edge, Chrome, Firefox, Opera, and Safari.

The parameter `insecure` could generate confusion, but that's means to alert the user when their browser has security issues.

Browser-Update has an advanced configuration where we can set up CSS, texts and other options such as reminders of the alert. But since we don't have any mockup we proceed with the default script.

### How to test it

You'll need to download an old version of your browser, remember that it's configured to 3 versions backward, so currently, you need any of these versions in order to get it works:

Chrome: 57 or previous
Safari: 5 or previous
Opera: 44 or previous
Firefox: 51 or previous
IE/Edge: 9 or previous

After you have an out of date browser go to the site and check an alert is displayed. 

### Screenshots

![screenshot from 2018-01-12 07-48-23](https://user-images.githubusercontent.com/3374009/34880836-ae03dbee-f77f-11e7-8ba6-d451ce413266.png)

### Reviewers

- [ ] @felipemontoya 

